### PR TITLE
Implement the `open` command in LaunchServices (#37)

### DIFF
--- a/Frameworks/LaunchServices/DBSchema_3_4.sql
+++ b/Frameworks/LaunchServices/DBSchema_3_4.sql
@@ -1,0 +1,2 @@
+ALTER TABLE applications ADD COLUMN bundleid text;
+UPDATE schema SET version=4;

--- a/Frameworks/LaunchServices/InitDB.sql
+++ b/Frameworks/LaunchServices/InitDB.sql
@@ -1,6 +1,6 @@
 CREATE TABLE schema (version int);
-INSERT INTO schema VALUES (3);
-CREATE TABLE applications (url text, basename text, version int, apprecord blob);
+INSERT INTO schema VALUES (4);
+CREATE TABLE applications (url text, basename text, version int, apprecord blob, bundleid text);
 CREATE TABLE typemap (uti text, application text, rank int);
 CREATE TABLE types (uti text, extensions text, mimetypes text, ostypes text, pboards text, conforms text);
 INSERT INTO types VALUES ('com.apple.alias-record','','','','','public.item,com.apple.resolvable');

--- a/Frameworks/LaunchServices/LaunchServices.h
+++ b/Frameworks/LaunchServices/LaunchServices.h
@@ -52,6 +52,7 @@ enum {
 typedef enum LSLaunchFlags : OptionBits {
     kLSLaunchDefaults = 0x00000001,
     kLSLaunchAndPrint = 0x00000002,
+    kLSLaunchAndWaitForExit = 0x00000004, // specific to Airyx
     kLSLaunchAndDisplayErrors = 0x00000040,
     kLSLaunchDontAddToRecents = 0x00000100,
     kLSLaunchDontSwitch = 0x00000200,
@@ -84,6 +85,8 @@ typedef struct LSLaunchURLSpec {
     CFArrayRef itemURLs;
     LSLaunchFlags launchFlags;
     const void *passThruParams; // ignored - not implemented
+    CFArrayRef taskArgs;        // specific to Airyx
+    CFDictionaryRef taskEnv;    // specific to Airyx
 } LSLaunchURLSpec;
 
 const CFStringRef    kCFBundleTypeExtensionsKey = CFSTR("CFBundleTypeExtensions");
@@ -116,7 +119,6 @@ Boolean LSIsAppDir(CFURLRef url);
 
 OSStatus LSOpenCFURLRef(CFURLRef inURL, CFURLRef _Nullable *outLaunchedURL);
 OSStatus LSOpenFromURLSpec(const LSLaunchURLSpec *inLaunchSpec, CFURLRef _Nullable *outLaunchedURL);
-OSStatus LSOpenFromURLSpecExtended(const LSLaunchURLSpec *inLaunchSpec, CFURLRef _Nullable *outLaunchedURL, CFArrayRef _Nullable taskArgs, CFDictionaryRef _Nullable taskEnv);
 OSStatus LSRegisterURL(CFURLRef inURL, Boolean inUpdate);
 OSStatus LSCanURLAcceptURL(CFURLRef inItemURL, CFURLRef inTargetURL, LSRolesMask inRoleMask, LSAcceptanceFlags inFlags, Boolean *outAcceptsItem);
 

--- a/Frameworks/LaunchServices/LaunchServices.h
+++ b/Frameworks/LaunchServices/LaunchServices.h
@@ -100,11 +100,9 @@ enum {
 typedef struct OpaqueLSSharedFileListRef *LSSharedFileListRef;
 typedef struct OpaqueLSSharedFileListItemRef *LSSharedFileListItemRef;
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
-
 //------------------------------------------------------------------------
 // These two functions are used by Filer but are otherwise internal only
 //------------------------------------------------------------------------

--- a/Frameworks/LaunchServices/LaunchServices.h
+++ b/Frameworks/LaunchServices/LaunchServices.h
@@ -116,6 +116,7 @@ Boolean LSIsAppDir(CFURLRef url);
 
 OSStatus LSOpenCFURLRef(CFURLRef inURL, CFURLRef _Nullable *outLaunchedURL);
 OSStatus LSOpenFromURLSpec(const LSLaunchURLSpec *inLaunchSpec, CFURLRef _Nullable *outLaunchedURL);
+OSStatus LSOpenFromURLSpecExtended(const LSLaunchURLSpec *inLaunchSpec, CFURLRef _Nullable *outLaunchedURL, CFArrayRef _Nullable taskArgs, CFDictionaryRef _Nullable taskEnv);
 OSStatus LSRegisterURL(CFURLRef inURL, Boolean inUpdate);
 OSStatus LSCanURLAcceptURL(CFURLRef inItemURL, CFURLRef inTargetURL, LSRolesMask inRoleMask, LSAcceptanceFlags inFlags, Boolean *outAcceptsItem);
 

--- a/Frameworks/LaunchServices/LaunchServices.mm
+++ b/Frameworks/LaunchServices/LaunchServices.mm
@@ -529,6 +529,11 @@ OSStatus LSOpenCFURLRef(CFURLRef inURL, CFURLRef _Nullable *outLaunchedURL)
 
 OSStatus LSOpenFromURLSpec(const LSLaunchURLSpec *inLaunchSpec, CFURLRef _Nullable *outLaunchedURL)
 {
+    return LSOpenFromURLSpecExtended(inLaunchSpec,outLaunchedURL,NULL,NULL);
+}
+
+OSStatus LSOpenFromURLSpecExtended(const LSLaunchURLSpec *inLaunchSpec, CFURLRef _Nullable *outLaunchedURL, CFArrayRef _Nullable taskArgs, CFDictionaryRef _Nullable taskEnv)
+{
     _LSInitializeDatabase();
 
     if(inLaunchSpec->appURL) {

--- a/Frameworks/LaunchServices/LaunchServices_private.h
+++ b/Frameworks/LaunchServices/LaunchServices_private.h
@@ -1,0 +1,38 @@
+/*
+ * Airyx LaunchServices
+ *
+ * Copyright (C) 2021 Zoe Knox <zoe@pixin.net>
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import <Foundation/Foundation.h>
+#import "LSAppRecord.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+BOOL LSFindRecordInDatabase(const NSURL *appURL, LSAppRecord **appRecord);
+BOOL LSFindRecordInDatabaseByBundleID(const NSString *bundleID, LSAppRecord **appRecord);
+OSStatus LSFindAppsForUTI(NSString *uti, NSMutableArray **outAppURLs);
+
+#ifdef __cplusplus
+}
+#endif

--- a/Frameworks/LaunchServices/Makefile
+++ b/Frameworks/LaunchServices/Makefile
@@ -11,4 +11,9 @@ LDFLAGS+= -L/usr/local/lib -lsqlite3 ${QT5LDFLAGS}
 
 build: all
 
+open: open.m
+	clang ${CFLAGS} -g -o ${.TARGET} ${.ALLSRC} \
+		-F${BUILDROOT}/System/Library/Frameworks \
+		-framework LaunchServices -framework Foundation
+
 .include <airyx.framework.mk>

--- a/Frameworks/LaunchServices/Makefile
+++ b/Frameworks/LaunchServices/Makefile
@@ -3,7 +3,7 @@
 FRAMEWORK=LaunchServices
 SRCS= LaunchServices.mm LSAppRecord.mm UTTypes.mm
 INCS= LaunchServices.h UTCoreTypes.h UTTypes.h
-RESOURCES= Info.plist InitDB.sql
+RESOURCES= Info.plist InitDB.sql DBSchema_3_4.sql
 QT5CFLAGS!= pkg-config --cflags Qt5Xdg
 QT5LDFLAGS!= pkg-config --libs Qt5Xdg
 CFLAGS+= ${FMWK_CFLAGS} -I.. -I../libobjc2 -I../Foundation/Headers ${QT5CFLAGS}

--- a/Frameworks/LaunchServices/open.m
+++ b/Frameworks/LaunchServices/open.m
@@ -1,6 +1,36 @@
+/*
+ * Airyx LaunchServices - `open` command
+ *
+ * Copyright (C) 2021 Zoe Knox <zoe@pixin.net>
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+
 #import <Foundation/Foundation.h>
 #import <Foundation/NSPlatform.h>
 #import "LaunchServices.h"
+#import "LaunchServices_private.h"
 
 void unimplemented(const char *msg);
 void showHelpAndExit(void);
@@ -12,6 +42,8 @@ void findHeaderNamed(NSString *header, LSLaunchURLSpec *spec);
 void openInputPipe(NSString *path);
 void openOutputPipe(NSString *path, int fd);
 
+static NSString *textedit = @"/Applications/TextEdit.app";
+
 int main(int argc, const char **argv)
 {
     LSLaunchURLSpec spec;
@@ -20,6 +52,9 @@ int main(int argc, const char **argv)
     NSArray *taskArgs = nil;
     NSMutableDictionary *taskEnv = [NSMutableDictionary new];
     NSMutableArray *files = [NSMutableArray new];
+
+    if(argc == 1)
+        showHelpAndExit();
 
     NSArray *argv_ = [[NSPlatform currentPlatform] arguments];
     NSEnumerator *args = [argv_ objectEnumerator];
@@ -38,25 +73,25 @@ int main(int argc, const char **argv)
                 showHelpAndExit();
             findApplicationByBundleID(bid, &spec);
         } else if([arg isEqualToString:@"-e"]) {
-            spec.appURL = (CFURLRef)[NSURL fileURLWithPath:@"file:///Applications/TextEdit.app"];
+            spec.appURL = (CFURLRef)[NSURL fileURLWithPath:textedit];
         } else if([arg isEqualToString:@"-t"]) {
             findDefaultTextEditor(&spec);
         } else if([arg isEqualToString:@"-f"]) {
             findDefaultTextEditor(&spec);
             pipeInputToTempAndOpen(&spec);
-        } else if([arg isEqualToString:@"-F"]) {
+        } else if([arg isEqualToString:@"-F"] || [arg isEqualToString:@"--fresh"]) {
             openFresh = YES;
-        } else if([arg isEqualToString:@"-W"]) {
+        } else if([arg isEqualToString:@"-W"] || [arg isEqualToString:@"--wait-apps"]) {
             waitForExit = YES;
-        } else if([arg isEqualToString:@"-R"]) {
+        } else if([arg isEqualToString:@"-R"] || [arg isEqualToString:@"--reveal"]) {
             revealInFiler = YES;
-        } else if([arg isEqualToString:@"-n"]) {
+        } else if([arg isEqualToString:@"-n"] || [arg isEqualToString:@"--new"]) {
             openNew = YES;
-        } else if([arg isEqualToString:@"-g"]) {
+        } else if([arg isEqualToString:@"-g"] || [arg isEqualToString:@"--background"]) {
             doNotRaiseWindow = YES;
-        } else if([arg isEqualToString:@"-j"]) {
+        } else if([arg isEqualToString:@"-j"] || [arg isEqualToString:@"--hide"]) {
             launchHidden = YES;
-        } else if([arg isEqualToString:@"-h"]) {
+        } else if([arg isEqualToString:@"-h"] || [arg isEqualToString:@"--header"]) {
             findingHeaders = YES;
         } else if([arg isEqualToString:@"-s"]) {
             NSString *sdk = [args nextObject];
@@ -72,12 +107,12 @@ int main(int argc, const char **argv)
                 showHelpAndExit();
             NSArray *pair = [var componentsSeparatedByString:@"="];
             [taskEnv setObject:[pair objectAtIndex:1] forKey:[pair objectAtIndex:0]];
-        } else if([arg isEqualToString:@"--stdin"]) {
+        } else if([arg isEqualToString:@"-i"] || [arg isEqualToString:@"--stdin"]) {
             NSString *path = [args nextObject];
             if(path == nil)
                 showHelpAndExit();
             openInputPipe(path);
-        } else if([arg isEqualToString:@"--stdout"]) {
+        } else if([arg isEqualToString:@"-o"] || [arg isEqualToString:@"--stdout"]) {
             NSString *path = [args nextObject];
             if(path == nil)
                 showHelpAndExit();
@@ -98,33 +133,104 @@ int main(int argc, const char **argv)
 
 void unimplemented(const char *msg)
 {
-    NSLog(@"Warning: option %s is not implemented", msg);
+    fprintf(stderr, "Warning: option %s is not implemented", msg);
 }
 
 void showHelpAndExit(void)
 {
-    NSLog(@"Usage help");
-    exit(-1);
+    fprintf(stderr, "Usage: open [-a <application>] [-b <bundle identifier>] [-e] [-t] [-f] [-F] [-R] [-W] [-n] [-j] [-g] [-h] [-s <sdk>] [filenames] [--args arguments]\n");
+    fprintf(stderr, "Opens files from the shell\n");
+    fprintf(stderr, "\tBy default, it opens each file using the default application for that file\n");
+    fprintf(stderr, "\tIf the file is a URL, it will be opened as a URL\n");
+    fprintf(stderr,"Options:\n");
+    fprintf(stderr,"\t-a               Opens with the specified application\n");
+    fprintf(stderr,"\t-b               Opens with the specified application bundle ID\n");
+    fprintf(stderr,"\t-e               Opens with TextEdit\n");
+    fprintf(stderr,"\t-t               Opens with the default text editor\n");
+    fprintf(stderr,"\t-f               Reads input from stdin and opens it in the default text editor\n");
+    fprintf(stderr,"\t-F --fresh       Launches a 'fresh' application, without restoring windows\n");
+    fprintf(stderr,"\t-R --reveal      Show files in Filer instead of opening\n");
+    fprintf(stderr,"\t-W --wait-apps   Wait for started applications to exit\n");
+    fprintf(stderr,"\t-n --new         Start a new copy of the application even if one is running\n");
+    fprintf(stderr,"\t-j --hide        Launch the application hidden\n");
+    fprintf(stderr,"\t-g --background  Do not bring the application to the foreground\n");
+    fprintf(stderr,"\t-h --header      Searches for headers matching the given names\n");
+    fprintf(stderr,"\t-s               For compatibility - ignored\n");
+    fprintf(stderr,"\t   --args        The remaining arguments are passed to the application being launched\n");
+    fprintf(stderr,"\t-i --stdin PATH  Connect stdin to PATH before launching the application\n");
+    fprintf(stderr,"\t-o --stdout PATH Connect stdout to PATH before launching the application\n");
+    fprintf(stderr,"\t   --stderr PATH Connect stderr to PATH before launching the application\n");
+    fprintf(stderr,"\t   --env VAR     Add VAR to the applications environment before launching, where VAR is formatted as NAME=VALUE\n\n");
+    exit(1);
 }
 
 void findApplicationByName(NSString *name, LSLaunchURLSpec *spec)
 {
-    NSLog(@"find App by Name %@",name);
+    LSAppRecord *appRecord = [LSAppRecord new];
+    NSURL *appURL = [NSURL fileURLWithPath:name];
+    if(LSFindRecordInDatabase(appURL, &appRecord) == YES) {
+        spec->appURL = (CFURLRef)[appRecord URL];
+        return;
+    }
+    
+    if([[appURL pathExtension] isEqualToString:@"app"] == NO) {
+        appURL = [appURL URLByAppendingPathExtension:@"app"];
+        if(LSFindRecordInDatabase(appURL, &appRecord) == YES) {
+            spec->appURL = (CFURLRef)[appRecord URL];
+            return;
+        }
+    } 
+
+    fprintf(stderr, "Unable to find application named %s\n", [name UTF8String]);
+    exit(1);
 }
 
 void findApplicationByBundleID(NSString *bid, LSLaunchURLSpec *spec)
 {
-    NSLog(@"find App by ID %@",bid);
+    LSAppRecord *appRecord = [LSAppRecord new];
+    if(LSFindRecordInDatabaseByBundleID(bid, &appRecord) == YES) {
+        spec->appURL = (CFURLRef)[appRecord URL];
+        return;
+    }
+    
+    fprintf(stderr, "open: failed while trying to determine the application with bundle identifier %s\n", [bid UTF8String]);
+    exit(1);
 }
 
 void findDefaultTextEditor(LSLaunchURLSpec *spec)
 {
-    NSLog(@"find default editor");
+    LSAppRecord *appRecord = [LSAppRecord new];
+    NSMutableArray *appCandidates = [NSMutableArray arrayWithCapacity:5];
+    if(LSFindAppsForUTI(@"public.text", &appCandidates) != 0) {
+        fprintf(stderr, "Unable to determine default text editor. Using TextEdit.\n");
+        spec->appURL = (CFURLRef)[NSURL fileURLWithPath:textedit];
+        return;
+    }
+    spec->appURL = (CFURLRef)[appCandidates firstObject];
 }
 
 void pipeInputToTempAndOpen(LSLaunchURLSpec *spec)
 {
-    NSLog(@"pipe into to temp");
+    char buf[1024], tempfile[25];
+    int len = 0;
+
+    memset(tempfile, 0, sizeof(tempfile));
+    strcpy(tempfile,"/tmp/open_XXXXXXXX"); 
+    mktemp(tempfile);
+    strcat(tempfile, ".txt");
+    int out = open(tempfile, O_CREAT|O_RDWR|O_EXCL, S_IRUSR|S_IWUSR);
+    if(out < 0) {
+        fprintf(stderr, "Unable to create temporary file for input\n");
+        exit(1);
+    }
+
+    while((len = read(0, buf, sizeof(buf))) > 0)
+        write(out, buf, len);
+    close(out);
+
+    spec->itemURLs = (CFArrayRef)[NSArray arrayWithObject:[NSURL fileURLWithPath:
+                               [NSString stringWithCString:tempfile]]];
+    LSOpenFromURLSpec(spec, NULL);
     exit(0);
 }
 

--- a/Frameworks/LaunchServices/open.m
+++ b/Frameworks/LaunchServices/open.m
@@ -46,7 +46,7 @@ static NSString *textedit = @"/Applications/TextEdit.app";
 
 int main(int argc, const char **argv)
 {
-    BOOL waitForExit = NO, findingHeaders = NO, revealInFiler = NO;
+    BOOL findingHeaders = NO, revealInFiler = NO;
     NSArray *taskArgs = nil;
     NSString *stdinPipe = nil, *stdoutPipe = nil, *stderrPipe = nil;
 
@@ -96,15 +96,15 @@ int main(int argc, const char **argv)
         } else if([arg isEqualToString:@"-F"] || [arg isEqualToString:@"--fresh"]) {
             unimplemented(arg);
         } else if([arg isEqualToString:@"-W"] || [arg isEqualToString:@"--wait-apps"]) {
-            waitForExit = YES;
+            spec.launchFlags |= kLSLaunchAndWaitForExit;
         } else if([arg isEqualToString:@"-R"] || [arg isEqualToString:@"--reveal"]) {
             revealInFiler = YES;
         } else if([arg isEqualToString:@"-n"] || [arg isEqualToString:@"--new"]) {
-            spec.launchFlags = kLSLaunchNewInstance;
+            spec.launchFlags |= kLSLaunchNewInstance;
         } else if([arg isEqualToString:@"-g"] || [arg isEqualToString:@"--background"]) {
-            spec.launchFlags = kLSLaunchDontSwitch;
+            spec.launchFlags |= kLSLaunchDontSwitch;
         } else if([arg isEqualToString:@"-j"] || [arg isEqualToString:@"--hide"]) {
-            spec.launchFlags = kLSLaunchAndHide;
+            spec.launchFlags |= kLSLaunchAndHide;
         } else if([arg isEqualToString:@"-h"] || [arg isEqualToString:@"--header"]) {
             findingHeaders = YES;
         } else if([arg isEqualToString:@"-s"]) {
@@ -144,6 +144,11 @@ int main(int argc, const char **argv)
 
     // now we are ready to launch!
 
+    if(revealInFiler) {
+        // send request to dbus to show files
+        return 0;
+    }
+
     if(stdinPipe)
         openInputPipe(stdinPipe);
     if(stdoutPipe)
@@ -152,8 +157,10 @@ int main(int argc, const char **argv)
         openOutputPipe(stderrPipe, 2);
 
     spec.itemURLs = (CFArrayRef)itemURLs;
+    spec.taskArgs = (CFArrayRef)taskArgs;
+    spec.taskEnv = (CFDictionaryRef)taskEnv;
 
-    return LSOpenFromURLSpecExtended(&spec, NULL, (CFArrayRef)taskArgs, (CFDictionaryRef)taskEnv);
+    return LSOpenFromURLSpec(&spec, NULL);
 }
 
 void unimplemented(NSString *msg)

--- a/Frameworks/LaunchServices/open.m
+++ b/Frameworks/LaunchServices/open.m
@@ -38,7 +38,6 @@ void findApplicationByName(NSString *name, LSLaunchURLSpec *spec);
 void findApplicationByBundleID(NSString *bid, LSLaunchURLSpec *spec);
 void findDefaultTextEditor(LSLaunchURLSpec *spec);
 NSURL *pipeInputToTempAndOpen(LSLaunchURLSpec *spec);
-void findHeaderNamed(NSString *header, LSLaunchURLSpec *spec);
 void openInputPipe(NSString *path);
 void openOutputPipe(NSString *path, int fd);
 
@@ -107,6 +106,7 @@ int main(int argc, const char **argv)
             spec.launchFlags |= kLSLaunchAndHide;
         } else if([arg isEqualToString:@"-h"] || [arg isEqualToString:@"--header"]) {
             findingHeaders = YES;
+            unimplemented(arg);
         } else if([arg isEqualToString:@"-s"]) {
             NSString *sdk = [args nextObject];
             unimplemented(arg);
@@ -261,11 +261,6 @@ NSURL * pipeInputToTempAndOpen(LSLaunchURLSpec *spec)
         write(out, buf, len);
     close(out);
     return [NSURL fileURLWithPath:[[NSString stringWithCString:tempfile] autorelease]]; 
-}
-
-void findHeaderNamed(NSString *header, LSLaunchURLSpec *spec)
-{
-    NSLog(@"find header %@",header);
 }
 
 void openInputPipe(NSString *path)

--- a/Frameworks/LaunchServices/open.m
+++ b/Frameworks/LaunchServices/open.m
@@ -1,0 +1,146 @@
+#import <Foundation/Foundation.h>
+#import <Foundation/NSPlatform.h>
+#import "LaunchServices.h"
+
+void unimplemented(const char *msg);
+void showHelpAndExit(void);
+void findApplicationByName(NSString *name, LSLaunchURLSpec *spec);
+void findApplicationByBundleID(NSString *bid, LSLaunchURLSpec *spec);
+void findDefaultTextEditor(LSLaunchURLSpec *spec);
+void pipeInputToTempAndOpen(LSLaunchURLSpec *spec);
+void findHeaderNamed(NSString *header, LSLaunchURLSpec *spec);
+void openInputPipe(NSString *path);
+void openOutputPipe(NSString *path, int fd);
+
+int main(int argc, const char **argv)
+{
+    LSLaunchURLSpec spec;
+    BOOL openFresh = NO, waitForExit = NO, openNew = NO, findingHeaders = NO;
+    BOOL revealInFiler = NO, launchHidden = NO, doNotRaiseWindow = NO;
+    NSArray *taskArgs = nil;
+    NSMutableDictionary *taskEnv = [NSMutableDictionary new];
+    NSMutableArray *files = [NSMutableArray new];
+
+    NSArray *argv_ = [[NSPlatform currentPlatform] arguments];
+    NSEnumerator *args = [argv_ objectEnumerator];
+    NSString *arg = [args nextObject]; // eat argv[0]
+
+    while(arg = [args nextObject]) {
+        // -a, -b, -e, -t, -f and -R are mutually exclusive
+        if([arg isEqualToString:@"-a"]) {
+            NSString *app = [args nextObject];
+            if(app == nil)
+                showHelpAndExit();
+            findApplicationByName(app, &spec);
+        } else if([arg isEqualToString:@"-b"]) {
+            NSString *bid = [args nextObject];
+            if(bid == nil)
+                showHelpAndExit();
+            findApplicationByBundleID(bid, &spec);
+        } else if([arg isEqualToString:@"-e"]) {
+            spec.appURL = (CFURLRef)[NSURL fileURLWithPath:@"file:///Applications/TextEdit.app"];
+        } else if([arg isEqualToString:@"-t"]) {
+            findDefaultTextEditor(&spec);
+        } else if([arg isEqualToString:@"-f"]) {
+            findDefaultTextEditor(&spec);
+            pipeInputToTempAndOpen(&spec);
+        } else if([arg isEqualToString:@"-F"]) {
+            openFresh = YES;
+        } else if([arg isEqualToString:@"-W"]) {
+            waitForExit = YES;
+        } else if([arg isEqualToString:@"-R"]) {
+            revealInFiler = YES;
+        } else if([arg isEqualToString:@"-n"]) {
+            openNew = YES;
+        } else if([arg isEqualToString:@"-g"]) {
+            doNotRaiseWindow = YES;
+        } else if([arg isEqualToString:@"-j"]) {
+            launchHidden = YES;
+        } else if([arg isEqualToString:@"-h"]) {
+            findingHeaders = YES;
+        } else if([arg isEqualToString:@"-s"]) {
+            NSString *sdk = [args nextObject];
+            unimplemented("-s");
+        } else if([arg isEqualToString:@"--args"]) {
+            NSInteger here = [argv_ indexOfObject:arg];
+            NSRange r = NSMakeRange(here, (argc - here));
+            taskArgs = [argv_ subarrayWithRange:r];
+            break;
+        } else if([arg isEqualToString:@"--env"]) {
+            NSString *var = [args nextObject];
+            if(var == nil)
+                showHelpAndExit();
+            NSArray *pair = [var componentsSeparatedByString:@"="];
+            [taskEnv setObject:[pair objectAtIndex:1] forKey:[pair objectAtIndex:0]];
+        } else if([arg isEqualToString:@"--stdin"]) {
+            NSString *path = [args nextObject];
+            if(path == nil)
+                showHelpAndExit();
+            openInputPipe(path);
+        } else if([arg isEqualToString:@"--stdout"]) {
+            NSString *path = [args nextObject];
+            if(path == nil)
+                showHelpAndExit();
+            openOutputPipe(path, 1);
+        } else if([arg isEqualToString:@"--stderr"]) {
+            NSString *path = [args nextObject];
+            if(path == nil)
+                showHelpAndExit();
+            openOutputPipe(path, 2);
+        } else
+            [files addObject:arg];
+    }
+
+    NSLog(@"files=%@\nargs=%@\nenv=%@",files,taskArgs,taskEnv);
+
+    return 0;
+}
+
+void unimplemented(const char *msg)
+{
+    NSLog(@"Warning: option %s is not implemented", msg);
+}
+
+void showHelpAndExit(void)
+{
+    NSLog(@"Usage help");
+    exit(-1);
+}
+
+void findApplicationByName(NSString *name, LSLaunchURLSpec *spec)
+{
+    NSLog(@"find App by Name %@",name);
+}
+
+void findApplicationByBundleID(NSString *bid, LSLaunchURLSpec *spec)
+{
+    NSLog(@"find App by ID %@",bid);
+}
+
+void findDefaultTextEditor(LSLaunchURLSpec *spec)
+{
+    NSLog(@"find default editor");
+}
+
+void pipeInputToTempAndOpen(LSLaunchURLSpec *spec)
+{
+    NSLog(@"pipe into to temp");
+    exit(0);
+}
+
+void findHeaderNamed(NSString *header, LSLaunchURLSpec *spec)
+{
+    NSLog(@"find header %@",header);
+}
+
+void openInputPipe(NSString *path)
+{
+    NSLog(@"open input pipe %@",path);
+}
+
+void openOutputPipe(NSString *path, int fd)
+{
+    NSLog(@"open output pipe %@ %d",path,fd);
+}
+
+


### PR DESCRIPTION
Adds a mostly compatible `open` command to LaunchServices.
Options `-a`, `-b`, `-e`, `-t`, `-f`, `-W`, `-j`, `-g`, `--args`, `--env`, `--stdin`, `--stdout`, and `--stderr` are implemented and working.
Option `-R` requires some work in Filer first.
Option `-n` cannot be implemented reliably for non-Cocoa apps and is currently a stub.
Header searching with `-s` and `-h` is not implemented yet.

This PR also updates the `launchservices.db` schema from v3 to v4, adding a `bundleid` column for fast lookup by bundle ID.

```
★ zoe@yuki ~/airyx/Frameworks/LaunchServicesᐳ ./open
Usage: open [-a <application>] [-b <bundle identifier>] [-e] [-t] [-f] [-F] [-R] [-W] [-n] [-j] [-g] [-h] [-s <sdk>] [filenames] [--args arguments]
Opens files from the shell
By default, it opens each file using the default application for that file
If the file is a URL, it will be opened as a URL
Options:
-a               Opens with the specified application
-b               Opens with the specified application bundle ID
-e               Opens with TextEdit
-t               Opens with the default text editor
-f               Reads input from stdin and opens it in the default text editor
-F --fresh       Launches a 'fresh' application, without restoring windows
-R --reveal      Show files in Filer instead of opening
-W --wait-apps   Wait for started applications to exit
-n --new         Start a new copy of the application even if one is running
-j --hide        Launch the application hidden
-g --background  Do not bring the application to the foreground
-h --header      Searches for headers matching the given names
-s               For compatibility - ignored
--args        The remaining arguments are passed to the application being launched
-i --stdin PATH  Connect stdin to PATH before launching the application
-o --stdout PATH Connect stdout to PATH before launching the application
--stderr PATH Connect stderr to PATH before launching the application
--env VAR     Add VAR to the applications environment before launching, where VAR is formatted as NAME=VALUE
```