### PR TITLE
Fix build badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# What is Airyx? ![](https://api.cirrus-ci.com/github/mszoek/airyx.svg?branch=main&task=airyx) [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
+# What is Airyx? [![Build Status](https://api.cirrus-ci.com/github/mszoek/airyx.svg?branch=main&task=airyx)](https://cirrus-ci.com/github/mszoek/airyx) [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 
 Airyx is a new open source OS project that aims to provide a similar experience and some compatibility with macOS on x86-64 sytems. It builds on the solid foundations of FreeBSD, existing open source packages in the same space, and new code to fill the gaps.
 


### PR DESCRIPTION
Makes build badge clickable for easier access to current build failures.